### PR TITLE
Change query logic to use `clean_content` rather than `content`

### DIFF
--- a/beanstalk/bot.py
+++ b/beanstalk/bot.py
@@ -124,7 +124,7 @@ async def on_message(message):
     if message.author.id == bot.user.id:
         return
 
-    queries = set(re.findall(QUERY_PATTERN, message.content))
+    queries = set(re.findall(QUERY_PATTERN, message.clean_content))
     for query in queries:
 
         # Choose the embed.


### PR DESCRIPTION
Potential enhancement.
[bot.py](https://github.com/dougblack/beanstalk/blob/4ae2838f228949be7e9e4d125e1aa2dec49dce20/beanstalk/bot.py#L127) currently uses [`content`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.content) in its check for card queries. This means that if a channel or user is tagged, the logic sees a numeric code rather than the name.

Changing the logic to use [`clean_content`](https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.clean_content) would allow queries with tags to query based on names.

I understand that this is an edge use case, and I didn't get a chance to test the change very extensively, but I thought it'd be a nice enhancement.